### PR TITLE
Use LISTEN_ADDRESS on the hashi-ui to avoid conflict on listen ports with grafana

### DIFF
--- a/grafana/templates/grafana.hcl
+++ b/grafana/templates/grafana.hcl
@@ -10,6 +10,7 @@ job "${job_name}" {
       driver = "docker"
       config {
         image   = "grafana/grafana"
+        network_mode = "host"
 
         port_map {
           http = 3000
@@ -27,7 +28,9 @@ job "${job_name}" {
         memory = ${mem_limit}
         network {
           mbits = ${net_limit}
-          port "http" {}
+          port "http" {
+            static = 3000
+          }
         }
       }
 
@@ -44,4 +47,3 @@ job "${job_name}" {
     }
   }
 }
-

--- a/hashi-ui/main.tf
+++ b/hashi-ui/main.tf
@@ -12,6 +12,7 @@ data "template_file" "hashi-ui" {
     nomad_enable  = "${var.nomad_enable}"
     nomad_address = "${var.nomad_address}"
     node_class    = "${var.node_class}"
+    listen_port = "${var.listen_port}"
   }
 }
 

--- a/hashi-ui/templates/hashi-ui-docker.hcl
+++ b/hashi-ui/templates/hashi-ui-docker.hcl
@@ -28,6 +28,7 @@ job "${job_name}" {
       env {
         NOMAD_ENABLE = ${nomad_enable}
         NOMAD_ADDR   = "${nomad_address}"
+        LISTEN_ADDRESS = "0.0.0.0:${listen_port}"
       }
 
       constraint {
@@ -44,7 +45,7 @@ job "${job_name}" {
           mbits = ${net_limit}
 
           port "http" {
-            static = 3000
+            static = "${listen_port}"
           }
         }
       }

--- a/hashi-ui/templates/hashi-ui-rkt.hcl
+++ b/hashi-ui/templates/hashi-ui-rkt.hcl
@@ -12,7 +12,7 @@ job "hashi-ui" {
       config {
         image        = "jippi/hashi-ui"
         port_map {
-          http = "3000-tcp"
+          http = "${listen_port}-tcp"
         }
       }
 
@@ -30,6 +30,7 @@ job "hashi-ui" {
       env {
         NOMAD_ENABLE = ${nomad_enable}
         NOMAD_ADDR   = "${nomad_address}"
+        LISTEN_ADDRESS = "0.0.0.0:${listen_port}"
       }
 
       constraint {
@@ -46,7 +47,7 @@ job "hashi-ui" {
           mbits = ${net_limit}
 
           port "http" {
-            static = 3000
+            static = "${listen_port}"
           }
         }
       }

--- a/hashi-ui/variables.tf
+++ b/hashi-ui/variables.tf
@@ -53,3 +53,8 @@ variable "nomad_address" {
   description = "Nomad address to use"
   default     = "http://http.nomad.service.consul:4646"
 }
+
+variable "listen_port" {
+  description = "Listening port for hashi-ui"
+  default = 5000
+}


### PR DESCRIPTION
This change intends to use the `LISTEN_ADDRESS` environment variable available to configure the `hashi-ui` container images (both `docker` and `rkt`) (haven't tested on `rkt`)

The default port of `hashi-ui` has been changed to `5000`

Reason:
Currently there is a conflict on port `3000` being used for both grafana and hashi-ui deployments

Output:
```
$ terraform apply tf.out
module.hashi-ui.nomad_job.hashi-ui: Creating...
  deregister_on_destroy:   "" => "true"
  deregister_on_id_change: "" => "true"
  jobspec:                 "" => "job \"hashi-ui\" {\n  region      = \"us\"\n  datacenters = [\"vagrant\"]\n  type        = \"service\"\n\n  group \"server\" {\n    count = 1\n\n    task \"hashi-ui\" {\n      driver = \"docker\"\n\n      config {\n        image        = \"jippi/hashi-ui\"\n        network_mode = \"host\"\n      }\n\n      service {\n        port = \"http\"\n\n        check {\n          type     = \"http\"\n          path     = \"/\"\n          interval = \"10s\"\n          timeout  = \"2s\"\n        }\n      }\n\n      env {\n        NOMAD_ENABLE = 1\n        NOMAD_ADDR   = \"http://10.0.2.15:4646\"\n        LISTEN_ADDRESS = \"0.0.0.0:5000\"\n      }\n\n      constraint {\n        attribute = \"${node.class}\"\n        operator  = \"=\"\n        value     = \"vagrant\"\n      }\n\n      resources {\n        cpu    = 100\n        memory = 64\n\n        network {\n          mbits = 5\n\n          port \"http\" {\n            static = \"5000\"\n          }\n        }\n      }\n    }\n  }\n}\n"
module.prometheus-exec.nomad_job.prometheus: Creating...
  deregister_on_destroy:   "" => "true"
  deregister_on_id_change: "" => "true"
  jobspec:                 "" => "job \"prometheus\" {\n  region      = \"us\"\n  datacenters = [\"vagrant\"]\n  type        = \"service\"\n\n  group \"prom\" {\n    count  = 1\n\n    task \"server\" {\n      driver = \"exec\"\n\n      artifact {\n        source      = \"https://github.com/prometheus/prometheus/releases/download/v1.8.2/prometheus-1.8.2.linux-amd64.tar.gz\"\n        destination = \"local/\"\n\n        options {\n          checksum = \"sha512:f7577d48dcf5a8945b39c67edc59bf09c8420df6860206d06ef8fb43907a298ecc8f4a01bbbadc600b42bb2a8ac44622d30cfdc18e255d977c59515baf97b284\"\n        }\n      }\n\n      config {\n        command = \"prometheus-1.8.2.linux-amd64/prometheus\"\n\n        args = [\n          \"-config.file=local/config.yaml\"\n        ]\n      }\n\n      constraint {\n        attribute = \"${node.class}\"\n        operator  = \"=\"\n        value     = \"vagrant\"\n      }\n\n      service {\n        port = \"http\"\n\n        check {\n          type     = \"http\"\n          path     = \"/\"\n          interval = \"30s\"\n          timeout  = \"5s\"\n        }\n      }\n\n      resources {\n        cpu    = 250\n        memory = 256\n        network {\n          mbits = 5\n\n          port \"http\" {\n            static = 9090\n          }\n        }\n      }\n\n      template {\n        data = <<EOH\nglobal:\n  scrape_interval: 30s\n  scrape_timeout: 30s\n\nscrape_configs:\n  # one for the server itself\n  - job_name: 'prometheus'\n    # Override the global default and scrape targets from this job every 5 seconds.\n    #scrape_interval: 5s\n    # metrics_path defaults to '/metrics'\n    # scheme defaults to 'http'.\n    static_configs:\n      - targets: ['localhost:9090']\n\n  # this scrapes using consul for service discovery\n  - job_name: 'consul-sd'\n    consul_sd_configs:\n      - server: 10.0.2.15:8500\n        token: b684a56c-cf86-443b-a48f-52056f21986f\n    relabel_configs:\n      - source_labels: ['__meta_consul_tags']\n        regex: .*,scrape-metrics,.*\n        action: keep\n    # - source_labels: [__meta_consul_node]\n    #   target_label: instance\n    # - source_labels: [__meta_consul_service]\n    #   target_label: job\nEOH\n\n        destination = \"local/config.yaml\"\n      }\n    }\n  }\n}\n"
module.node_exporter.nomad_job.node_exporter: Creating...
  deregister_on_destroy:   "" => "true"
  deregister_on_id_change: "" => "true"
  jobspec:                 "" => "job \"node_exporter\" {\n  region      = \"us\"\n  datacenters = [\"vagrant\"]\n  type        = \"system\"\n\n  group \"node_exporter\" {\n\n    task \"node_exporter\" {\n      driver = \"raw_exec\"\n\n      artifact {\n        source      = \"https://github.com/prometheus/node_exporter/releases/download/v0.15.1/node_exporter-0.15.1.linux-amd64.tar.gz\"\n        destination = \"local/\"\n\n        options {\n          checksum = \"sha512:d4e52db9577a795231ce1901d3a11fefb9152848bff2283ba04b8d196461a1ddc55ec07d6a3a939b7775c7ecbb06dff4c3ff89c2cd97b89c696bef49d59f8b5a\"\n        }\n      }\n\n      config {\n        command = \"node_exporter-0.15.1.linux-amd64/node_exporter\"\n        args    = []\n      }\n\n      service {\n        name = \"node-exporter\"\n        port = \"metrics\"\n        tags = [ \"scrape-metrics\" ]\n\n        check {\n          type     = \"http\"\n          path     = \"/\"\n          interval = \"30s\"\n          timeout  = \"5s\"\n        }\n      }\n\n      resources {\n        cpu    = 100\n        memory = 100\n        network {\n          mbits = 3\n\n          port \"metrics\" {\n            static = 9100\n          }\n        }\n      }\n    }\n  }\n}\n"
module.grafana.nomad_job.grafana: Creating...
  deregister_on_destroy:   "" => "true"
  deregister_on_id_change: "" => "true"
  jobspec:                 "" => "job \"grafana\" {\n  region      = \"us\"\n  datacenters = [\"vagrant\"]\n  type        = \"service\"\n\n  group \"ui\" {\n    count  = 1\n\n    task \"ui\" {\n      driver = \"docker\"\n      config {\n        image   = \"grafana/grafana\"\n        network_mode = \"host\"\n\n        port_map {\n          http = 3000\n        }\n      }\n\n      constraint {\n        attribute = \"${node.class}\"\n        operator  = \"=\"\n        value     = \"vagrant\"\n      }\n\n      resources {\n        cpu    = 250\n        memory = 256\n        network {\n          mbits = 5\n          port \"http\" {\n            static = 3000\n          }\n        }\n      }\n\n      service {\n        port = \"http\"\n\n        check {\n          type     = \"http\"\n          path     = \"/\"\n          interval = \"30s\"\n          timeout  = \"5s\"\n        }\n      }\n    }\n  }\n}\n"
module.prometheus-exec.nomad_job.prometheus: Creation complete after 0s (ID: prometheus)
module.node_exporter.nomad_job.node_exporter: Creation complete after 0s (ID: node_exporter)
module.grafana.nomad_job.grafana: Creation complete after 0s (ID: grafana)
module.hashi-ui.nomad_job.hashi-ui: Creation complete after 0s (ID: hashi-ui)

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
```

Screenshots:

![grafana-port-conflict](https://user-images.githubusercontent.com/922486/47492835-86d4e680-d86b-11e8-8f87-a2a4859a0bc8.png)
![hashi-ui-port-conflict](https://user-images.githubusercontent.com/922486/47492836-86d4e680-d86b-11e8-9eb0-8d1bd1d70509.png)
![nomad-port-conflict](https://user-images.githubusercontent.com/922486/47492837-86d4e680-d86b-11e8-8751-a5151c0b397e.png)
