### PR TITLE
Bump Prometheus version from 1.8.2 to 2.4.3

### DIFF
--- a/grafana/templates/grafana.hcl
+++ b/grafana/templates/grafana.hcl
@@ -10,6 +10,7 @@ job "${job_name}" {
       driver = "docker"
       config {
         image   = "grafana/grafana"
+        network_mode = "host"
 
         port_map {
           http = 3000
@@ -27,7 +28,9 @@ job "${job_name}" {
         memory = ${mem_limit}
         network {
           mbits = ${net_limit}
-          port "http" {}
+          port "http" {
+            static = 3000
+          }
         }
       }
 
@@ -44,4 +47,3 @@ job "${job_name}" {
     }
   }
 }
-

--- a/hashi-ui/main.tf
+++ b/hashi-ui/main.tf
@@ -12,6 +12,7 @@ data "template_file" "hashi-ui" {
     nomad_enable  = "${var.nomad_enable}"
     nomad_address = "${var.nomad_address}"
     node_class    = "${var.node_class}"
+    listen_port = "${var.listen_port}"
   }
 }
 

--- a/hashi-ui/templates/hashi-ui-docker.hcl
+++ b/hashi-ui/templates/hashi-ui-docker.hcl
@@ -28,6 +28,7 @@ job "${job_name}" {
       env {
         NOMAD_ENABLE = ${nomad_enable}
         NOMAD_ADDR   = "${nomad_address}"
+        LISTEN_ADDRESS = "0.0.0.0:${listen_port}"
       }
 
       constraint {
@@ -44,7 +45,7 @@ job "${job_name}" {
           mbits = ${net_limit}
 
           port "http" {
-            static = 3000
+            static = "${listen_port}"
           }
         }
       }

--- a/hashi-ui/templates/hashi-ui-rkt.hcl
+++ b/hashi-ui/templates/hashi-ui-rkt.hcl
@@ -12,7 +12,7 @@ job "hashi-ui" {
       config {
         image        = "jippi/hashi-ui"
         port_map {
-          http = "3000-tcp"
+          http = "${listen_port}-tcp"
         }
       }
 
@@ -30,6 +30,7 @@ job "hashi-ui" {
       env {
         NOMAD_ENABLE = ${nomad_enable}
         NOMAD_ADDR   = "${nomad_address}"
+        LISTEN_ADDRESS = "0.0.0.0:${listen_port}"
       }
 
       constraint {
@@ -46,7 +47,7 @@ job "hashi-ui" {
           mbits = ${net_limit}
 
           port "http" {
-            static = 3000
+            static = "${listen_port}"
           }
         }
       }

--- a/hashi-ui/variables.tf
+++ b/hashi-ui/variables.tf
@@ -53,3 +53,8 @@ variable "nomad_address" {
   description = "Nomad address to use"
   default     = "http://http.nomad.service.consul:4646"
 }
+
+variable "listen_port" {
+  description = "Listening port for hashi-ui"
+  default = 5000
+}

--- a/prometheus-exec/templates/prometheus-exec.hcl
+++ b/prometheus-exec/templates/prometheus-exec.hcl
@@ -22,7 +22,7 @@ job "prometheus" {
         command = "prometheus-${version}.linux-amd64/prometheus"
 
         args = [
-          "-config.file=local/config.yaml"
+          "--config.file=local/config.yaml"
         ]
       }
 

--- a/prometheus-exec/variables.tf
+++ b/prometheus-exec/variables.tf
@@ -20,12 +20,12 @@ variable "datacenters" {
 
 variable "version" {
   description = "version of prometheus to download, verify, and run"
-  default     = "1.8.2"
+  default     = "2.4.3"
 }
 
 variable "checksum" {
   description = "version of prometheus to download, verify, and run"
-  default     = "sha512:f7577d48dcf5a8945b39c67edc59bf09c8420df6860206d06ef8fb43907a298ecc8f4a01bbbadc600b42bb2a8ac44622d30cfdc18e255d977c59515baf97b284"
+  default     = "sha512:2993c49b774f7be7246c669fbe4e82d2cbe348063091b2cdc827df540d00832147cf948f114278ea5d368d6dd03812cbed43888ed223f13a7846f0ef137389d5"
 }
 
 variable "cpu_limit" {


### PR DESCRIPTION
NOTE: This PR is based on top of #4 

![bump-prometheus](https://user-images.githubusercontent.com/922486/47711726-eceeae80-dc5b-11e8-8914-99a8bef1752e.png)
![bump-prometheus-grafana](https://user-images.githubusercontent.com/922486/47711727-eceeae80-dc5b-11e8-81fa-6924d9305a37.png)
